### PR TITLE
mode prompt: dim `[]`

### DIFF
--- a/functions/_fish_print-bindings-mode.fish
+++ b/functions/_fish_print-bindings-mode.fish
@@ -1,0 +1,11 @@
+function _fish_print-bindings-mode --argument-names={color,letter} --description='Print the editor mode in bold with dimmed `[]`'
+    set_color --bold --dim {$color}
+    echo -n \[
+
+    set_color normal
+    set_color --bold $color
+    echo -n {$letter}
+
+    set_color --bold --dim {$color}
+    echo \]
+end

--- a/functions/fish_default_mode_prompt.fish
+++ b/functions/fish_default_mode_prompt.fish
@@ -5,20 +5,15 @@ function fish_default_mode_prompt --description "Display vi/helix prompt mode"
         or test "$fish_key_bindings" = fish_hybrid_key_bindings
         switch $fish_bind_mode
             case default
-                set_color --bold red
-                echo '[N]'
+                _fish_print-bindings-mode red N
             case insert
-                set_color --bold green
-                echo '[I]'
+                _fish_print-bindings-mode green I
             case replace_one
-                set_color --bold green
-                echo '[R]'
+                _fish_print-bindings-mode green R
             case replace
-                set_color --bold cyan
-                echo '[R]'
+                _fish_print-bindings-mode cyan R
             case visual
-                set_color --bold magenta
-                echo '[V]'
+                _fish_print-bindings-mode magenta V
         end
         set_color normal
         echo -n ' '


### PR DESCRIPTION
To make the mode more noticeable, the square brackets surrounding the letter indicating the mode are dimmed.
This highlights what actually changes when the mode is switched.

<img width="393" height="514" alt="dim-showcase" src="https://github.com/user-attachments/assets/b79a3105-f3f4-4e03-a320-753f469aca61" />
