### PR TITLE
prompt: `set_color`: `normal` → `--reset`

### DIFF
--- a/functions/fish_default_mode_prompt.fish
+++ b/functions/fish_default_mode_prompt.fish
@@ -20,7 +20,7 @@ function fish_default_mode_prompt --description "Display vi/helix prompt mode"
                 set_color --bold magenta
                 echo '[V]'
         end
-        set_color normal
+        set_color --reset
         echo -n ' '
     end
 end


### PR DESCRIPTION
> [!NOTE]
> This commit comes directly from the [upstream](https://github.com/fish-shell/fish-shell/commit/86794646898c1a1ed0d8d3e2e8084be1ee301dbf), and affects the [file](https://github.com/fish-shell/fish-shell/blob/master/share/functions/fish_default_mode_prompt.fish) in the same way

In the prompt, `set_color normal` is changed to be `set_color --reset`.